### PR TITLE
OSGi manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,27 @@
                     </dependency>
                 </dependencies>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>net.vz.mongodb.jackson</Export-Package>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
         <extensions>
             <extension>


### PR DESCRIPTION
Hi,

I added the Maven Bundle Plugin to the pom.xml. This will automatically add OSGi manifest headers to the generated jar file, so the it can be used as an OSGi bundle. Only the classes in net.vz.mongodb.jackson are exported, the classes in 'internal' are hidden.

Paul
