### PR TITLE
Fixed - ClassCastException for generic array cast (T[])

### DIFF
--- a/src/main/java/net/vz/mongodb/jackson/JacksonDBCollection.java
+++ b/src/main/java/net/vz/mongodb/jackson/JacksonDBCollection.java
@@ -1593,11 +1593,10 @@ public class JacksonDBCollection<T, K> {
         }
     }
 
-    @SuppressWarnings({"unchecked"})
-    T[] convertFromDbObjects(DBObject... dbObjects) throws MongoException {
-        T[] results = (T[]) new Object[dbObjects.length];
+    List<T> convertFromDbObjects(DBObject... dbObjects) throws MongoException {
+    	final List<T> results = new ArrayList<T>();
         for (int i = 0; i < dbObjects.length; i++) {
-            results[i] = convertFromDbObject(dbObjects[i]);
+            results.add(convertFromDbObject(dbObjects[i]));
         }
         return results;
     }

--- a/src/main/java/net/vz/mongodb/jackson/WriteResult.java
+++ b/src/main/java/net/vz/mongodb/jackson/WriteResult.java
@@ -15,6 +15,9 @@
  */
 package net.vz.mongodb.jackson;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.mongodb.CommandResult;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
@@ -37,7 +40,7 @@ public class WriteResult<T, K> {
     private final JacksonDBCollection<T, K> jacksonDBCollection;
     private final DBObject[] dbObjects;
     private final com.mongodb.WriteResult writeResult;
-    private T[] objects;
+    private List<T> objects;
 
     protected WriteResult(JacksonDBCollection<T, K> jacksonDBCollection, com.mongodb.WriteResult writeResult, DBObject... dbObjects) {
         this.jacksonDBCollection = jacksonDBCollection;
@@ -58,7 +61,7 @@ public class WriteResult<T, K> {
         if (dbObjects.length == 0) {
             throw new MongoException("No objects to return");
         }
-        return getSavedObjects()[0];
+        return getSavedObjects().get(0);
     }
 
     /**
@@ -72,7 +75,7 @@ public class WriteResult<T, K> {
      *
      * @return The saved objects
      */
-    public T[] getSavedObjects() {
+    public List<T> getSavedObjects() {
         // Lazily generate the object, in case it's not needed.
         if (objects == null) {
             if (dbObjects.length > 0) {
@@ -108,19 +111,11 @@ public class WriteResult<T, K> {
      *
      * @return The saved IDs
      */
-
-    @SuppressWarnings("unchecked") 
-    public Iterable<K> getSavedIds() {
+ 
+    public List<K> getSavedIds() {
         if (dbObjects.length > 0 && dbObjects[0] instanceof JacksonDBObject) {
             throw new UnsupportedOperationException("Generated _id retrieval not supported when using stream serialization");
         }
-        /*
-        K[] ids = (K[]) new Object[dbObjects.length]; this cast isn't possible?!?!
-        for (int i = 0; i < dbObjects.length; i++) {
-            ids[i] = jacksonDBCollection.convertFromDbId(dbObjects[i].get("_id"));
-        }
-        return ids;
-        */
 
         List<K> ids = new ArrayList<K>();
         for (int i = 0; i < dbObjects.length; i++) {

--- a/src/main/java/net/vz/mongodb/jackson/WriteResult.java
+++ b/src/main/java/net/vz/mongodb/jackson/WriteResult.java
@@ -108,14 +108,25 @@ public class WriteResult<T, K> {
      *
      * @return The saved IDs
      */
-    public K[] getSavedIds() {
+
+    @SuppressWarnings("unchecked") 
+    public Iterable<K> getSavedIds() {
         if (dbObjects.length > 0 && dbObjects[0] instanceof JacksonDBObject) {
             throw new UnsupportedOperationException("Generated _id retrieval not supported when using stream serialization");
         }
-        K[] ids = (K[]) new Object[dbObjects.length];
+        /*
+        K[] ids = (K[]) new Object[dbObjects.length]; this cast isn't possible?!?!
         for (int i = 0; i < dbObjects.length; i++) {
             ids[i] = jacksonDBCollection.convertFromDbId(dbObjects[i].get("_id"));
         }
+        return ids;
+        */
+
+        List<K> ids = new ArrayList<K>();
+        for (int i = 0; i < dbObjects.length; i++) {
+            ids.add((K) jacksonDBCollection.convertFromDbId(dbObjects[i].get("_id")));
+        }
+
         return ids;
     }
 

--- a/src/test/java/net/vz/mongodb/jackson/TestJacksonDBCollection.java
+++ b/src/test/java/net/vz/mongodb/jackson/TestJacksonDBCollection.java
@@ -144,5 +144,23 @@ public class TestJacksonDBCollection extends MongoDBTestBase {
         assertThat(remaining, Matchers.hasSize(2));
         assertThat(remaining, not(contains(object)));
     }
+    
+    @Test
+    public void testFindAndModifyWithBuilder(){
+    	coll.insert(new MockObject("id1", "ten", 10));
+    	coll.insert(new MockObject("id2", "ten", 10));
+    	
+    	MockObject result1 = coll.findAndModify(DBQuery.is("_id", "id1"), null, null, false, DBUpdate.set("integer", 20).set("string", "twenty"), true, false);
+    	assertThat(result1.integer, equalTo(20));
+    	assertThat(result1.string, equalTo("twenty"));
+    	
+    	MockObject result2 = coll.findAndModify(DBQuery.is("_id", "id2"), null, null, false, DBUpdate.set("integer", 30).set("string", "thirty"), true, false);
+    	assertThat(result2.integer, equalTo(30));
+    	assertThat(result2.string, equalTo("thirty"));
+    	
+    	coll.removeById("id1");
+    	coll.removeById("id2");
+    	
+    }
 
 }

--- a/src/test/java/net/vz/mongodb/jackson/TestWriteResult.java
+++ b/src/test/java/net/vz/mongodb/jackson/TestWriteResult.java
@@ -41,4 +41,20 @@ public class TestWriteResult extends MongoDBTestBase {
         MockObject o = new MockObject("blah", "ten", 10);
         assertThat(coll.insert(o).getSavedObject(), equalTo(o));
     }
+    
+    @Test
+    public void testGetSavedIds(){
+    	final WriteResult<MockObject, String> result = coll.insert(new MockObject("A", "a", 1), new MockObject("B", "b", 2));
+    	assertThat(result.getSavedIds().get(0), equalTo("A"));
+    	assertThat(result.getSavedIds().get(1), equalTo("B"));
+    }
+
+    @Test
+    public void testGetSavedObjects(){
+    	final MockObject a = new MockObject("A", "a", 1);
+    	final MockObject b = new MockObject("B", "b", 2);
+    	final WriteResult<MockObject, String> result = coll.insert(a, b);
+    	assertThat(result.getSavedObjects().get(0), equalTo(a));
+    	assertThat(result.getSavedObjects().get(1), equalTo(b));
+    }    
 }


### PR DESCRIPTION
Hi,

I fixed - ClassCastException `(T[]) new Object[dbObjects.length]` because generic array cast `T[]` isn't possible. Use `List<T>` instead.

This exception would occur if primitive array is used outside:

``` java
...
WriteResult<MockObject, String> result = coll.insert(new MockObject("A", "a", 1), new MockObject("B", "b", 2));
assertThat(result.getSavedIds()[0], equalTo("A"));
assertThat(result.getSavedIds()[0], equalTo("B"));
...
```

Thanks for your great work!
