### PR TITLE
findAndModify syntactic sugar

### DIFF
--- a/src/main/java/net/vz/mongodb/jackson/JacksonDBCollection.java
+++ b/src/main/java/net/vz/mongodb/jackson/JacksonDBCollection.java
@@ -594,7 +594,7 @@ public class JacksonDBCollection<T, K> {
      * @return the object
      */
     public T findAndModify(DBObject query, DBObject fields, DBObject sort, boolean remove, DBUpdate.Builder update, boolean returnNew, boolean upsert) {
-        return this.findAndModify(query, fields, sort, remove, update.serialiseAndGet(objectMapper), returnNew, upsert));
+        return this.findAndModify(query, fields, sort, remove, update.serialiseAndGet(objectMapper), returnNew, upsert);
     }
 
 

--- a/src/main/java/net/vz/mongodb/jackson/JacksonDBCollection.java
+++ b/src/main/java/net/vz/mongodb/jackson/JacksonDBCollection.java
@@ -580,6 +580,22 @@ public class JacksonDBCollection<T, K> {
     public T findAndModify(DBObject query, DBObject fields, DBObject sort, boolean remove, DBObject update, boolean returnNew, boolean upsert) {
         return convertFromDbObject(dbCollection.findAndModify(serializeFields(query), fields, sort, remove, update, returnNew, upsert));
     }
+    
+    /**
+     * Finds the first document in the query and updates it.
+     *
+     * @param query     query to match
+     * @param fields    fields to be returned
+     * @param sort      sort to apply before picking first document
+     * @param remove    if true, document found will be removed
+     * @param update    update to apply
+     * @param returnNew if true, the updated document is returned, otherwise the old document is returned (or it would be lost forever)
+     * @param upsert    do upsert (insert if document not present)
+     * @return the object
+     */
+    public T findAndModify(DBObject query, DBObject fields, DBObject sort, boolean remove, DBUpdate.Builder update, boolean returnNew, boolean upsert) {
+        return this.findAndModify(query, fields, sort, remove, update.serialiseAndGet(objectMapper), returnNew, upsert));
+    }
 
 
     /**


### PR DESCRIPTION
Hi,

This method is really missing, instead of constructing BasicDBObject() like this:

```
Query query = DBQuery.is("authToken", authToken);
BasicDBObject update = new BasicDBObject("$set", new BasicDBObject("lastAccess", System.currentTimeMillis()));
session = coll.sessions().findAndModify(query, null, null, false, update, true, false);
```

one can use builder for creating an update query:

```
Query query = DBQuery.is("authToken", authToken);
Builder update = DBUpdate.set("lastAccess", System.currentTimeMillis());
session = coll.sessions().findAndModify(query, null, null, false, update, true, false);
```
