### PR TITLE
_id property of polymorphic types is not handled correctly

### DIFF
--- a/src/main/java/net/vz/mongodb/jackson/internal/util/IdHandlerFactory.java
+++ b/src/main/java/net/vz/mongodb/jackson/internal/util/IdHandlerFactory.java
@@ -55,6 +55,10 @@ public class IdHandlerFactory {
 
         JsonDeserializer deserializer = objectMapper.getDeserializerProvider().findTypedValueDeserializer(
                 objectMapper.copyDeserializationConfig(), SimpleType.construct(klass), null);
+        if ("org.codehaus.jackson.map.deser.StdDeserializerProvider$WrappedDeserializer".equals(deserializer.getClass().getName())) {
+        	// Cannot use instanceof on a class that's not visible, so using reflection
+        	deserializer = (JsonDeserializer) privateGet(deserializer, "_deserializer");
+        }
         if (deserializer instanceof BeanDeserializer) {
             // First priority is a property creator, see if one exists
             Object propertyBasedCreator = privateGet(deserializer, "_propertyBasedCreator");


### PR DESCRIPTION
When the @JsonTypeInfo and @JsonSubTypes annotations are used on a class that being persisted to MongoDb using mongo-jackson-mapper, the _id property is not correctly identified by the IdHandlerFactory, since the root JsonDeserializer will not be the BeanDeserializer, but a WrappedDeserializer.
